### PR TITLE
Remove main branch from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Django CI
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [ dev, production ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ dev, production ]
 
 jobs:
   test:


### PR DESCRIPTION
## Update CI Workflow to Remove main Branch

**Purpose**: Remove `main` from `Django CI` workflow since `dev` is the base branch.

**Changes**:
- Updated `.github/workflows/django-ci.yml` to include only `dev` and `production` in `push` and `pull_request` triggers.