### PR TITLE
Fix STATIC_ROOT for Collectstatic and Configure Static File Serving for Render

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ media
 # If your build process includes running collectstatic, then you probably don't need or want to include staticfiles/
 # in your Git repository. Update and uncomment the following line accordingly.
 # <django-project-name>/staticfiles/
+staticfiles/
+
 
 ### Django.Python Stack ###
 # Byte-compiled / optimized / DLL files

--- a/akibapamoja_backend/settings.py
+++ b/akibapamoja_backend/settings.py
@@ -137,6 +137,8 @@ USE_TZ = True
 
 # Static files
 STATIC_URL = 'static/'
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+
 
 # Auto field
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'


### PR DESCRIPTION
On Render, the Swagger UI CSS file (swagger-ui.css) was served with a MIME type of text/html instead of text/css, causing the browser to reject it due to strict MIME checking.
