### PR TITLE
Fix: add JSONParser to MeViewSet to support JSON requests

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -4,6 +4,7 @@ from rest_framework.decorators import action
 from rest_framework.parsers import MultiPartParser, FormParser, JSONParser
 from rest_framework_simplejwt.token_blacklist.models import BlacklistedToken
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+from rest_framework_simplejwt.tokens import RefreshToken
 
 
 from users.models import User

--- a/users/views.py
+++ b/users/views.py
@@ -1,8 +1,7 @@
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import viewsets, permissions, status, response
 from rest_framework.decorators import action
-from rest_framework.parsers import MultiPartParser, FormParser
-from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework.parsers import MultiPartParser, FormParser, JSONParser
 from rest_framework_simplejwt.token_blacklist.models import BlacklistedToken
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
@@ -128,7 +127,7 @@ class LoginRefreshView(TokenRefreshView):
 
 class MeViewSet(viewsets.ViewSet):
     permission_classes = [permissions.IsAuthenticated]
-    parser_classes = [MultiPartParser, FormParser]  
+    parser_classes = [JSONParser, MultiPartParser, FormParser]  
 
     @swagger_auto_schema(
         responses={200: UserSerializer}


### PR DESCRIPTION
## Description:

This pull request fixes a 415 Unsupported Media Type error that occurred when sending JSON PATCH requests to /api/users/me/.

Changes Made:

- Added JSONParser to parser_classes in MeViewSet.

- Ensures the endpoint can now handle both application/json and multipart/form-data requests.